### PR TITLE
feat: call process.exit(1) during postinstall

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,12 @@ if (require.main === module) {
         // eslint-disable-next-line no-console
         console.warn('Duplicate: %s', duplicate);
       });
+      if (
+        duplicates.length &&
+        process.env.npm_lifecycle_event === 'postinstall'
+      ) {
+        process.exit(1);
+      }
     })
     .catch(function(error) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
`yarn` does not allow `postinstall` scripts to write to [`stdout`/`stderr`](https://github.com/yarnpkg/yarn/issues/5476). This prevents us from informing users about package duplicates. Apparently, crashing the installation is all we can do in this case.

This PR adds support for this exact use case.

